### PR TITLE
Transform absolute file paths to file URI scheme

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,12 @@ var binPath = phantomjs.path;
 module.exports = function(){
     'use strict';
     return through.obj(function (file, enc, cb) {
+        var absolutePath = path.resolve(file.path),
+            isAbsolutePath = absolutePath.indexOf(file.path) >= 0;
+
         var childArgs = [
             path.join(__dirname, 'runner.js'),
-            file.path
+            (isAbsolutePath ? 'file:///' + absolutePath.replace(/\\/g, '/') : file.path)
         ];
 
         if (file.isStream()) {

--- a/test/main.js
+++ b/test/main.js
@@ -3,6 +3,7 @@
 
 var assert = require('assert');
 var gutil = require('gulp-util');
+var path = require('path');
 var qunit = require('../index');
 var out = process.stdout.write.bind(process.stdout);
 
@@ -24,6 +25,29 @@ describe('gulp-qunit', function() {
 
         stream.write(new gutil.File({
             path: './qunit/test-runner.html',
+            contents: new Buffer('')
+        }));
+
+        stream.end();
+    });
+
+    it('tests should pass with absolute source paths', function(cb) {
+        this.timeout(5000);
+
+        var stream = qunit();
+
+        process.stdout.write = function (str) {
+            //out(str);
+
+            if (/10 passed. 0 failed./.test(str)) {
+                assert(true);
+                process.stdout.write = out;
+                cb();
+            }
+        };
+
+        stream.write(new gutil.File({
+            path: path.resolve('./qunit/test-runner.html'),
             contents: new Buffer('')
         }));
 


### PR DESCRIPTION
This is a fix for the issues reported in #3, #7 and maybe #4.
1. Phantomjs appears to have issues processing relative paths for referenced files (e.g., script/style refs) when its webpage is created via an absolute path. (I was unable to find a relevant issue on the phantomjs GH page.)
2. `gulp.src` produces absolute paths in some cases/environments, which will trigger (1) when using this plugin. I'm not really clear on when this occurs, but it happens on my Win8.1/x64 machine.

This fix will determine if a file path is absolute and, if so, will transform it to the file URI scheme (e.g., `file:///c:/path/to/test.html`), which phantomjs _can_ handle. Relative file paths remain untouched.

I also included a test case demonstrating the behaviour.

---

For anyone else affected by this issue, there is a workaround that you can add to your gulpfile. Fixing it here in the repository would obviously be preferable, but the following works in my environment:

``` js
var gulp = require("gulp");
var qunit = require("gulp-qunit");
var path = require("path"),
var util = require('util');
var Transform = require('stream').Transform;

util.inherits(FilePathToUrl, Transform);

function FilePathToUrl(options){
    Transform.call(this, options);
}

FilePathToUrl.prototype._transform = function(file, encoding, done) {
    file.path = 'file:///' + path.resolve(file.path).replace(/\\/g, '/');
    this.push(file);
    return done();
};

function toUrl() {
    return new FilePathToUrl({ objectMode: true });
}

gulp.task("test", function() {
    return gulp.src("./qunit/test-runner.html")
        .pipe(toUrl())
        .pipe(qunit());
});
```
