### PR TITLE
Coloured output

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.js]
+indent_style = space
+indent_size = 4

--- a/index.js
+++ b/index.js
@@ -26,8 +26,13 @@ module.exports = function(){
             gutil.log('Testing ' + file.relative);
 
             if (stdout) {
-                stdout = stdout.trim(); // Trim trailing cr-lf
-                gutil.log(stdout);
+                try {
+                    var result = JSON.parse(stdout.trim());
+                    var output = 'Took ' + result.runtime + ' ms to run ' + chalk.blue(result.total) + ' tests. ' + chalk.green(result.passed) + ' passed, ' + chalk.red(result.failed) + ' failed.';
+                    gutil.log(output);
+                } catch(e) {
+                    gutil.log(stdout.trim());
+                }
             }
 
             if (stderr) {

--- a/index.js
+++ b/index.js
@@ -27,12 +27,18 @@ module.exports = function(){
 
             if (stdout) {
                 try {
-                    var result = JSON.parse(stdout.trim());
-                    var output = 'Took ' + result.runtime + ' ms to run ' + chalk.blue(result.total) + ' tests. ' + chalk.green(result.passed) + ' passed, ' + chalk.red(result.failed) + ' failed.';
-                    gutil.log(output);
-                } catch(e) {
-                    gutil.log(stdout.trim());
-                }
+                  var out = JSON.parse(stdout.trim());
+                  var result = out.result;
+                  var output = 'Took ' + result.runtime + ' ms to run ' + chalk.blue(result.total) + ' tests. ' + chalk.green(result.passed) + ' passed, ' + chalk.red(result.failed) + ' failed.';
+                  gutil.log(output);
+
+                  if(out.exceptions) {
+                    for(var test in out.exceptions) {
+                      output = '\n' + chalk.red('Test failed') + ': ' + chalk.red(test) + ': \n' + out.exceptions[test].join('\n  ');
+                      gutil.log(output);
+                    }
+                  }
+                } catch(e) {}
             }
 
             if (stderr) {
@@ -43,6 +49,8 @@ module.exports = function(){
             if (err) {
                 gutil.log('gulp-qunit: ' + chalk.red('✖ ') + 'QUnit assertions failed in ' + chalk.blue(file.relative));
                 this.emit('error', new gutil.PluginError('gulp-qunit', err));
+            } else {
+              gutil.log('gulp-qunit: ' + chalk.green('✔ ') + 'QUnit assertions all passed in ' + chalk.blue(file.relative));
             }
 
             this.push(file);

--- a/runner.js
+++ b/runner.js
@@ -14,140 +14,136 @@
 /*global phantom:false, require:false, console:false, window:false, QUnit:false */
 
 (function() {
-  'use strict';
+    'use strict';
 
-  var url, page, timeout,
-    args = require('system').args;
+    var url, page, timeout,
+        args = require('system').args;
 
-  // arg[0]: scriptName, args[1...]: arguments
-  if (args.length < 2 || args.length > 3) {
-    console.error('Usage:\n  phantomjs runner.js [url-of-your-qunit-testsuite] [timeout-in-seconds]');
-    phantom.exit(1);
-  }
-
-  url = args[1];
-  page = require('webpage').create();
-  if (args[2] !== undefined) {
-    timeout = parseInt(args[2], 10);
-  }
-
-  // Route `console.log()` calls from within the Page context to the main Phantom context (i.e. current `this`)
-  page.onConsoleMessage = function(msg) {
-    console.log(msg);
-  };
-
-  page.onInitialized = function() {
-    page.evaluate(addLogging);
-  };
-
-  page.onCallback = function(message) {
-    var result,
-      failed;
-
-    if (message) {
-      if (message.name === 'QUnit.done') {
-        result = message.data;
-        failed = !result || !result.total || result.failed;
-
-        if (!result.total) {
-          console.error('No tests were executed. Are you loading tests asynchronously?');
-        }
-
-        phantom.exit(failed ? 1 : 0);
-      }
-    }
-  };
-
-  page.open(url, function(status) {
-    if (status !== 'success') {
-      console.error('Unable to access network: ' + status);
-      phantom.exit(1);
-    } else {
-      // Cannot do this verification with the 'DOMContentLoaded' handler because it
-      // will be too late to attach it if a page does not have any script tags.
-      var qunitMissing = page.evaluate(function() { return (typeof QUnit === 'undefined' || !QUnit); });
-      if (qunitMissing) {
-        console.error('The `QUnit` object is not present on this page.');
+    // arg[0]: scriptName, args[1...]: arguments
+    if (args.length < 2 || args.length > 3) {
+        console.error('Usage:\n  phantomjs runner.js [url-of-your-qunit-testsuite] [timeout-in-seconds]');
         phantom.exit(1);
-      }
-
-      // Set a timeout on the test running, otherwise tests with async problems will hang forever
-      if (typeof timeout === 'number') {
-        setTimeout(function() {
-          console.error('The specified timeout of ' + timeout + ' seconds has expired. Aborting...');
-          phantom.exit(1);
-        }, timeout * 1000);
-      }
-
-      // Do nothing... the callback mechanism will handle everything!
     }
-  });
 
-  function addLogging() {
-    window.document.addEventListener('DOMContentLoaded', function() {
-      var currentTestAssertions = [],
-        testExceptions = {};
+    url = args[1];
+    page = require('webpage').create();
+    if (args[2] !== undefined) {
+        timeout = parseInt(args[2], 10);
+    }
 
-      QUnit.log(function(details) {
-        var response;
+    // Route `console.log()` calls from within the Page context to the main Phantom context (i.e. current `this`)
+    page.onConsoleMessage = function(msg) {
+        console.log(msg);
+    };
 
-        // Ignore passing assertions
-        if (details.result) {
-          return;
+    page.onInitialized = function() {
+        page.evaluate(addLogging);
+    };
+
+    page.onCallback = function(message) {
+        var result,
+            failed;
+
+        if (message) {
+            if (message.name === 'QUnit.done') {
+                result = message.data;
+                failed = !result || !result.total || result.failed;
+
+                if (!result.total) {
+                    console.error('No tests were executed. Are you loading tests asynchronously?');
+                }
+
+                phantom.exit(failed ? 1 : 0);
+            }
         }
+    };
 
-        response = details.message || '';
+    page.open(url, function(status) {
+        if (status !== 'success') {
+            console.error('Unable to access network: ' + status);
+            phantom.exit(1);
+        } else {
+            // Cannot do this verification with the 'DOMContentLoaded' handler because it
+            // will be too late to attach it if a page does not have any script tags.
+            var qunitMissing = page.evaluate(function() { return (typeof QUnit === 'undefined' || !QUnit); });
+            if (qunitMissing) {
+                console.error('The `QUnit` object is not present on this page.');
+                phantom.exit(1);
+            }
 
-        if (typeof details.expected !== 'undefined') {
-          if (response) {
-            response += ', ';
-          }
+            // Set a timeout on the test running, otherwise tests with async problems will hang forever
+            if (typeof timeout === 'number') {
+                setTimeout(function() {
+                    console.error('The specified timeout of ' + timeout + ' seconds has expired. Aborting...');
+                    phantom.exit(1);
+                }, timeout * 1000);
+            }
 
-          response += 'expected: ' + details.expected + ', but was: ' + details.actual;
+            // Do nothing... the callback mechanism will handle everything!
         }
+    });
 
-        if (details.source) {
-          response += "\n" + details.source;
-        }
+    function addLogging() {
+        window.document.addEventListener('DOMContentLoaded', function() {
+            var currentTestAssertions = [],
+                testExceptions = {};
 
-        currentTestAssertions.push('Failed assertion: ' + response);
-      });
+            QUnit.log(function(details) {
+                var response;
 
-      QUnit.testDone(function(result) {
-        var i,
-          len,
-          name = '';
+                // Ignore passing assertions
+                if (details.result) {
+                    return;
+                }
 
-        if (result.module) {
-          name += result.module + ': ';
-        }
-        name += result.name;
+                response = details.message || '';
 
-        if (result.failed) {
-          var exceptions = currentTestAssertions.slice(0)[0].split('\n');
-          testExceptions[name] = exceptions.map(function(e) { return e.trim(); });
-          // console.log('\n' + 'Test failed: ' + name);
+                if (typeof details.expected !== 'undefined') {
+                    if (response) {
+                        response += ', ';
+                    }
 
-          // for (i = 0, len = currentTestAssertions.length; i < len; i++) {
-          //   console.log('    ' + currentTestAssertions[i]);
-          // }
-        }
+                    response += 'expected: ' + details.expected + ', but was: ' + details.actual;
+                }
 
-        currentTestAssertions.length = 0;
-      });
+                if (details.source) {
+                    response += "\n" + details.source;
+                }
 
-      QUnit.done(function(result) {
-        console.log(JSON.stringify({
-          result: result,
-          exceptions: testExceptions
-        }))
-        if (typeof window.callPhantom === 'function') {
-          window.callPhantom({
-            'name': 'QUnit.done',
-            'data': result
-          });
-        }
-      });
-    }, false);
-  }
+                currentTestAssertions.push('Failed assertion: ' + response);
+            });
+
+            QUnit.testDone(function(result) {
+                var i,
+                    len,
+                    name = '';
+
+                if (result.module) {
+                    name += result.module + ': ';
+                }
+                name += result.name;
+
+                if (result.failed) {
+                    var exceptions = currentTestAssertions.slice(0)[0].split('\n');
+                    testExceptions[name] = exceptions.map(function(e) { return e.trim(); });
+                }
+
+                currentTestAssertions.length = 0;
+            });
+
+            QUnit.done(function(result) {
+                console.log(JSON.stringify({
+                    result: result,
+                    exceptions: testExceptions
+                }));
+
+                if (typeof window.callPhantom === 'function') {
+                    window.callPhantom({
+                        'name': 'QUnit.done',
+                        'data': result
+                    });
+                }
+            });
+        }, false);
+    }
 })();

--- a/runner.js
+++ b/runner.js
@@ -85,7 +85,8 @@
 
   function addLogging() {
     window.document.addEventListener('DOMContentLoaded', function() {
-      var currentTestAssertions = [];
+      var currentTestAssertions = [],
+        testExceptions = {};
 
       QUnit.log(function(details) {
         var response;
@@ -123,21 +124,23 @@
         name += result.name;
 
         if (result.failed) {
-          console.log('\n' + 'Test failed: ' + name);
+          var exceptions = currentTestAssertions.slice(0)[0].split('\n');
+          testExceptions[name] = exceptions.map(function(e) { return e.trim(); });
+          // console.log('\n' + 'Test failed: ' + name);
 
-          for (i = 0, len = currentTestAssertions.length; i < len; i++) {
-            console.log('    ' + currentTestAssertions[i]);
-          }
+          // for (i = 0, len = currentTestAssertions.length; i < len; i++) {
+          //   console.log('    ' + currentTestAssertions[i]);
+          // }
         }
 
         currentTestAssertions.length = 0;
       });
 
       QUnit.done(function(result) {
-        if(result.failed === 0) {
-          console.log(JSON.stringify(result))
-        }
-
+        console.log(JSON.stringify({
+          result: result,
+          exceptions: testExceptions
+        }))
         if (typeof window.callPhantom === 'function') {
           window.callPhantom({
             'name': 'QUnit.done',

--- a/runner.js
+++ b/runner.js
@@ -14,135 +14,137 @@
 /*global phantom:false, require:false, console:false, window:false, QUnit:false */
 
 (function() {
-	'use strict';
+  'use strict';
 
-	var url, page, timeout,
-		args = require('system').args;
+  var url, page, timeout,
+    args = require('system').args;
 
-	// arg[0]: scriptName, args[1...]: arguments
-	if (args.length < 2 || args.length > 3) {
-		console.error('Usage:\n  phantomjs runner.js [url-of-your-qunit-testsuite] [timeout-in-seconds]');
-		phantom.exit(1);
-	}
+  // arg[0]: scriptName, args[1...]: arguments
+  if (args.length < 2 || args.length > 3) {
+    console.error('Usage:\n  phantomjs runner.js [url-of-your-qunit-testsuite] [timeout-in-seconds]');
+    phantom.exit(1);
+  }
 
-	url = args[1];
-	page = require('webpage').create();
-	if (args[2] !== undefined) {
-		timeout = parseInt(args[2], 10);
-	}
+  url = args[1];
+  page = require('webpage').create();
+  if (args[2] !== undefined) {
+    timeout = parseInt(args[2], 10);
+  }
 
-	// Route `console.log()` calls from within the Page context to the main Phantom context (i.e. current `this`)
-	page.onConsoleMessage = function(msg) {
-		console.log(msg);
-	};
+  // Route `console.log()` calls from within the Page context to the main Phantom context (i.e. current `this`)
+  page.onConsoleMessage = function(msg) {
+    console.log(msg);
+  };
 
-	page.onInitialized = function() {
-		page.evaluate(addLogging);
-	};
+  page.onInitialized = function() {
+    page.evaluate(addLogging);
+  };
 
-	page.onCallback = function(message) {
-		var result,
-			failed;
+  page.onCallback = function(message) {
+    var result,
+      failed;
 
-		if (message) {
-			if (message.name === 'QUnit.done') {
-				result = message.data;
-				failed = !result || !result.total || result.failed;
+    if (message) {
+      if (message.name === 'QUnit.done') {
+        result = message.data;
+        failed = !result || !result.total || result.failed;
 
-				if (!result.total) {
-					console.error('No tests were executed. Are you loading tests asynchronously?');
-				}
+        if (!result.total) {
+          console.error('No tests were executed. Are you loading tests asynchronously?');
+        }
 
-				phantom.exit(failed ? 1 : 0);
-			}
-		}
-	};
+        phantom.exit(failed ? 1 : 0);
+      }
+    }
+  };
 
-	page.open(url, function(status) {
-		if (status !== 'success') {
-			console.error('Unable to access network: ' + status);
-			phantom.exit(1);
-		} else {
-			// Cannot do this verification with the 'DOMContentLoaded' handler because it
-			// will be too late to attach it if a page does not have any script tags.
-			var qunitMissing = page.evaluate(function() { return (typeof QUnit === 'undefined' || !QUnit); });
-			if (qunitMissing) {
-				console.error('The `QUnit` object is not present on this page.');
-				phantom.exit(1);
-			}
+  page.open(url, function(status) {
+    if (status !== 'success') {
+      console.error('Unable to access network: ' + status);
+      phantom.exit(1);
+    } else {
+      // Cannot do this verification with the 'DOMContentLoaded' handler because it
+      // will be too late to attach it if a page does not have any script tags.
+      var qunitMissing = page.evaluate(function() { return (typeof QUnit === 'undefined' || !QUnit); });
+      if (qunitMissing) {
+        console.error('The `QUnit` object is not present on this page.');
+        phantom.exit(1);
+      }
 
-			// Set a timeout on the test running, otherwise tests with async problems will hang forever
-			if (typeof timeout === 'number') {
-				setTimeout(function() {
-					console.error('The specified timeout of ' + timeout + ' seconds has expired. Aborting...');
-					phantom.exit(1);
-				}, timeout * 1000);
-			}
+      // Set a timeout on the test running, otherwise tests with async problems will hang forever
+      if (typeof timeout === 'number') {
+        setTimeout(function() {
+          console.error('The specified timeout of ' + timeout + ' seconds has expired. Aborting...');
+          phantom.exit(1);
+        }, timeout * 1000);
+      }
 
-			// Do nothing... the callback mechanism will handle everything!
-		}
-	});
+      // Do nothing... the callback mechanism will handle everything!
+    }
+  });
 
-	function addLogging() {
-		window.document.addEventListener('DOMContentLoaded', function() {
-			var currentTestAssertions = [];
+  function addLogging() {
+    window.document.addEventListener('DOMContentLoaded', function() {
+      var currentTestAssertions = [];
 
-			QUnit.log(function(details) {
-				var response;
+      QUnit.log(function(details) {
+        var response;
 
-				// Ignore passing assertions
-				if (details.result) {
-					return;
-				}
+        // Ignore passing assertions
+        if (details.result) {
+          return;
+        }
 
-				response = details.message || '';
+        response = details.message || '';
 
-				if (typeof details.expected !== 'undefined') {
-					if (response) {
-						response += ', ';
-					}
+        if (typeof details.expected !== 'undefined') {
+          if (response) {
+            response += ', ';
+          }
 
-					response += 'expected: ' + details.expected + ', but was: ' + details.actual;
-				}
+          response += 'expected: ' + details.expected + ', but was: ' + details.actual;
+        }
 
-				if (details.source) {
-					response += "\n" + details.source;
-				}
+        if (details.source) {
+          response += "\n" + details.source;
+        }
 
-				currentTestAssertions.push('Failed assertion: ' + response);
-			});
+        currentTestAssertions.push('Failed assertion: ' + response);
+      });
 
-			QUnit.testDone(function(result) {
-				var i,
-					len,
-					name = '';
+      QUnit.testDone(function(result) {
+        var i,
+          len,
+          name = '';
 
-				if (result.module) {
-					name += result.module + ': ';
-				}
-				name += result.name;
+        if (result.module) {
+          name += result.module + ': ';
+        }
+        name += result.name;
 
-				if (result.failed) {
-					console.log('\n' + 'Test failed: ' + name);
+        if (result.failed) {
+          console.log('\n' + 'Test failed: ' + name);
 
-					for (i = 0, len = currentTestAssertions.length; i < len; i++) {
-						console.log('    ' + currentTestAssertions[i]);
-					}
-				}
+          for (i = 0, len = currentTestAssertions.length; i < len; i++) {
+            console.log('    ' + currentTestAssertions[i]);
+          }
+        }
 
-				currentTestAssertions.length = 0;
-			});
+        currentTestAssertions.length = 0;
+      });
 
-			QUnit.done(function(result) {
-				console.log('\n' + 'Took ' + result.runtime +  'ms to run ' + result.total + ' tests. ' + result.passed + ' passed, ' + result.failed + ' failed.');
+      QUnit.done(function(result) {
+        if(result.failed === 0) {
+          console.log(JSON.stringify(result))
+        }
 
-				if (typeof window.callPhantom === 'function') {
-					window.callPhantom({
-						'name': 'QUnit.done',
-						'data': result
-					});
-				}
-			});
-		}, false);
-	}
+        if (typeof window.callPhantom === 'function') {
+          window.callPhantom({
+            'name': 'QUnit.done',
+            'data': result
+          });
+        }
+      });
+    }, false);
+  }
 })();

--- a/test/main.js
+++ b/test/main.js
@@ -3,6 +3,7 @@
 
 'use strict';
 var assert = require('assert');
+var chalk = require('chalk');
 var gutil = require('gulp-util');
 var path = require('path');
 var qunit = require('../index');
@@ -16,6 +17,7 @@ describe('gulp-qunit', function() {
 
         process.stdout.write = function (str) {
             //out(str);
+            str = chalk.stripColor(str);
 
             if (/10 passed. 0 failed./.test(str)) {
                 assert(true);
@@ -37,8 +39,11 @@ describe('gulp-qunit', function() {
 
         var stream = qunit();
 
+
         process.stdout.write = function (str) {
             //out(str);
+
+            str = chalk.stripColor(str);
 
             if (/10 passed. 0 failed./.test(str)) {
                 assert(true);


### PR DESCRIPTION
Hey!

I'm really enjoying this plugin but always felt the output could be coloured a little more to help pull out the important bits of information.

What this PR does is:

- add `.editorconfig` with your desired settings (4 spaces as tabs) and reindent runner.js accordingly (apologies, this makes the diff a little messy).
- Change `runner.js` so it logs a stringified object containing all the info on the tests and stack traces.
- use Chalk in `index.js` to colour output.

I have attached some screenshots of the output now, showing it for success and for failures.

![screen shot 2014-06-21 at 17 33 17](https://cloud.githubusercontent.com/assets/193238/3349422/a4cd5cea-f962-11e3-93b6-47b76bd32875.png)
![screen shot 2014-06-21 at 17 33 35](https://cloud.githubusercontent.com/assets/193238/3349423/a4ce623e-f962-11e3-915c-6a704ad9273e.png)
![screen shot 2014-06-21 at 17 33 49](https://cloud.githubusercontent.com/assets/193238/3349424/a4ceca3a-f962-11e3-88bd-1b63cac33ec3.png)

Let me know what you think!

