### PR TITLE
Allow passing options to PhantomJS

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,15 +7,16 @@ var through = require('through2');
 var phantomjs = require('phantomjs');
 var binPath = phantomjs.path;
 
-module.exports = function(){
+module.exports = function(params){
+    var options = params || {};
     return through.obj(function (file, enc, cb) {
         var absolutePath = path.resolve(file.path),
             isAbsolutePath = absolutePath.indexOf(file.path) >= 0;
 
-        var childArgs = [
+        var childArgs = (options['phantomjs-options'] || []).concat([
             path.join(__dirname, 'runner.js'),
             (isAbsolutePath ? 'file:///' + absolutePath.replace(/\\/g, '/') : file.path)
-        ];
+        ]);
 
         if (file.isStream()) {
             this.emit('error', new gutil.PluginError('gulp-qunit', 'Streaming not supported'));


### PR DESCRIPTION
For issue [#14] this allows to pass the required argument this way:

``` js
gulp.task('test:int', function() {
    return gulp.src('./test/test.html')
        .pipe(qunit({'phantomjs-options': ['--ssl-protocol=tlsv1']}))
});
```

This can probably be useful for other things too.
