### PR TITLE
Work-around to avoid "Unsafe JavaScript attempt to access frame" warning

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -53,7 +53,10 @@
 					console.error('No tests were executed. Are you loading tests asynchronously?');
 				}
 
-				phantom.exit(failed ? 1 : 0);
+				// Work-around to avoid "Unsafe JavaScript attempt to access frame" warning in PhantomJS 1.9.8.
+				// See: https://github.com/ariya/phantomjs/issues/12697
+				page.close();
+				setTimeout(function () { phantom.exit(failed ? 1 : 0) }, 0);
 			}
 		}
 	};


### PR DESCRIPTION
## Problem

Using gulp-qunit 1.0.0 with PhantomJS 1.9.12, following warning is output.

> Unsafe JavaScript attempt to access frame with URL about:blank from frame with URL file:///path/to/node_modules/gulp-qunit/runner.js. Domains, protocols and ports must match.

This is a issue of PhantomJS. Please see: https://github.com/ariya/phantomjs/issues/12697
## Change

I add work-around to avoid "Unsafe JavaScript attempt to access frame" warning.
## Tests

We can confirm that "Unsafe JavaScript attempt to access frame" warning is avoided by this change:
(I think test is not needed, so this change was not committed.)

``` diff
diff --git a/test/main.js b/test/main.js
index a21eb24..290960e 100644
--- a/test/main.js
+++ b/test/main.js
@@ -10,15 +10,19 @@ var assert = require('assert'),
     out = process.stdout.write.bind(process.stdout);

 describe('gulp-qunit', function() {
+    function assertUnsafeJSAttemptToAccessFrameWarningNotExist(msg) {
+        return !/Unsafe JavaScript attempt to access frame with URL about:blank from frame with URL/.test(msg)
+    }
+
     it('tests should pass', function(cb) {
         this.timeout(5000);

         var stream = qunit();

         process.stdout.write = function (str) {
-            //out(str);
+            out(str);

-            if (/10 passed. 0 failed./.test(str)) {
+            if (/10 passed. 0 failed./.test(str) && assertUnsafeJSAttemptToAccessFrameWarningNotExist(str)) {
                 assert(true);
                 process.stdout.write = out;
                 cb();
@@ -39,9 +43,9 @@ describe('gulp-qunit', function() {
         var stream = qunit({'phantomjs-options': ['--ssl-protocol=any']});

         process.stdout.write = function (str) {
-            //out(str);
+            out(str);

-            if (/10 passed. 0 failed./.test(str)) {
+            if (/10 passed. 0 failed./.test(str) && assertUnsafeJSAttemptToAccessFrameWarningNotExist(str)) {
                 assert(true);
                 process.stdout.write = out;
                 cb();
@@ -62,9 +66,9 @@ describe('gulp-qunit', function() {
         var stream = qunit();

         process.stdout.write = function (str) {
-            //out(str);
+            out(str);

-            if (/10 passed. 0 failed./.test(str)) {
+            if (/10 passed. 0 failed./.test(str) && assertUnsafeJSAttemptToAccessFrameWarningNotExist(str)) {
                 assert(true);
                 process.stdout.write = out;
                 cb();
@@ -89,9 +93,9 @@ describe('gulp-qunit', function() {
         });

         process.stdout.write = function (str) {
-            //out(str);
+            out(str);

-            if (/10 passed. 0 failed./.test(str)) {
+            if (/10 passed. 0 failed./.test(str) && assertUnsafeJSAttemptToAccessFrameWarningNotExist(str)) {
                 assert(true);
                 process.stdout.write = out;
                 cb();
```

Thanks.
