### PR TITLE
Actually pass phantomjs-options on to PhantomJS

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,14 +15,15 @@ module.exports = function (params) {
         var absolutePath = path.resolve(file.path),
             isAbsolutePath = absolutePath.indexOf(file.path) >= 0;
 
-        var childArgs = [
+        var childArgs = [];
+        if (options['phantomjs-options'] && options['phantomjs-options'].length) {
+            childArgs = childArgs.concat( options['phantomjs-options'] );
+        }
+
+        childArgs = childArgs.concat([
             path.join(__dirname, 'runner.js'),
             (isAbsolutePath ? 'file:///' + absolutePath.replace(/\\/g, '/') : file.path)
-        ];
-
-        if (options['phantomjs-options'] && options['phantomjs-options'].length) {
-            childArgs.concat( options['phantomjs-options'] );
-        }
+        ]);
 
         if (file.isStream()) {
             this.emit('error', new gutil.PluginError('gulp-qunit', 'Streaming not supported'));

--- a/test/main.js
+++ b/test/main.js
@@ -56,6 +56,40 @@ describe('gulp-qunit', function() {
         stream.end();
     });
 
+    it('tests should not run when passing --help to PhantomJS', function(cb) {
+        this.timeout(5000);
+
+        var stream = qunit({'phantomjs-options': ['--help']});
+
+        process.stdout.write = function (str) {
+            //out(str);
+
+            if (/10 passed. 0 failed./.test(str)) {
+                assert(false, 'No tests should run when passing --help to PhantomJS');
+                process.stdout.write = out;
+                cb();
+                return;
+            }
+
+            var lines = str.split('\n');
+            for (var i = 0; i < lines.length; i++) {
+                var line = lines[i];
+                if (/.*--help.*Shows this message and quits/.test(line)) {
+                    assert(true);
+                    process.stdout.write = out;
+                    cb();
+                }
+            }
+        };
+
+        stream.write(new gutil.File({
+            path: './qunit/test-runner.html',
+            contents: new Buffer('')
+        }));
+
+        stream.end();
+    });
+
     it('tests should pass with absolute source paths', function(cb) {
         this.timeout(5000);
 


### PR DESCRIPTION
Before this change, options specified using...

qunit({'phantomjs-options': ['--ssl-protocol=any']})

... were silently dropped by gulp-qunit.

The test case for this change passes --help to PhantomJS and verifies
that:
a) No tests are run
b) Some help is received

Without the changes to index.js, this test case fails.
