### PR TITLE
Fix parsing issue when colorizing output

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,21 +44,23 @@ module.exports = function (params) {
                     var out,
                         result;
 
-                    if (stdout.indexOf('{') !== -1) {
-                        out = JSON.parse(stdout.trim());
-                        result = out.result;
+                    stdout.toString().split('\n').forEach(function(line) {
+                        if (line.indexOf('{') !== -1) {
+                            out = JSON.parse(line.trim());
+                            result = out.result;
 
-                        gutil.log('Took ' + result.runtime + ' ms to run ' + chalk.blue(result.total) + ' tests. ' + chalk.green(result.passed) + ' passed, ' + chalk.red(result.failed) + ' failed.');
+                            gutil.log('Took ' + result.runtime + ' ms to run ' + chalk.blue(result.total) + ' tests. ' + chalk.green(result.passed) + ' passed, ' + chalk.red(result.failed) + ' failed.');
 
-                        if(out.exceptions) {
-                            for(var test in out.exceptions) {
-                                gutil.log('\n' + chalk.red('Test failed') + ': ' + chalk.red(test) + ': \n' + out.exceptions[test].join('\n  '));
+                            if(out.exceptions) {
+                                for(var test in out.exceptions) {
+                                    gutil.log('\n' + chalk.red('Test failed') + ': ' + chalk.red(test) + ': \n' + out.exceptions[test].join('\n  '));
+                                }
                             }
+                        } else {
+                            line = line.trim(); // Trim trailing cr-lf
+                            gutil.log(line);
                         }
-                    } else {
-                        stdout = stdout.trim(); // Trim trailing cr-lf
-                        gutil.log(stdout);
-                    }
+                    });
                 } catch (e) {
                     this.emit('error', new gutil.PluginError('gulp-qunit', e));
                 }

--- a/test/fixtures/passing.html
+++ b/test/fixtures/passing.html
@@ -14,6 +14,8 @@
     <div id="qunit-fixture"></div>
 
     <script>
+      console.log('Arbitrary console logging');
+
       // Let's test this function
       function isEven(val) {
         return val % 2 === 0;


### PR DESCRIPTION
When the tested page logs something to the console, ```stdout``` not only contains the test result but rather something like this:
```bash
Arbitrary console logging
{"result":{"failed":0,"passed":10,"total":10,"runtime":4},"exceptions":{}}

```

This does not play well with ```JSON.parse```.

Suggested solution: Parsing ```stdout``` line by line.