### PR TITLE
Changes phantomjs runner resolution.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function (params) {
         }
 
         childArgs.push(
-            path.join(__dirname, './node_modules/qunit-phantomjs-runner/runner-json.js'),
+            require.resolve('qunit-phantomjs-runner'),
             (isAbsolutePath ? 'file:///' + absolutePath.replace(/\\/g, '/') : file.path)
         );
 


### PR DESCRIPTION
Since NPM 3.0 the phantomjs module is installed slightly differently to
before. Now use require.resolve to find the runner-json.js.

Fixes #26.