### PR TITLE
multiple phantomjs options as an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,11 @@ module.exports = function (params) {
             childArgs = [];
 
         if (options['phantomjs-options'] && options['phantomjs-options'].length) {
-            childArgs.push(options['phantomjs-options']);
+            if (Array.isArray(options['phantomjs-options'])) {
+                childArgs = childArgs.concat(options['phantomjs-options']);
+            } else {
+                childArgs.push(options['phantomjs-options']);
+            }
         }
 
         childArgs.push(

--- a/test/main.js
+++ b/test/main.js
@@ -100,6 +100,28 @@ describe('gulp-qunit', function() {
 
         stream.end();
     });
+    
+    it('tests should pass with more than one options', function(done) {
+        var stream = qunit({'phantomjs-options': ['--ignore-ssl-errors=true', '--web-security=false']});
+
+        process.stdout.write = function (str) {
+            str = chalk.stripColor(str);
+
+            if (/10 passed. 0 failed./.test(str)) {
+                assert(true);
+                process.stdout.write = out;
+                done();
+            }
+        };
+
+        stream.write(new gutil.File({
+            path: './test/fixtures/passing.html',
+            contents: new Buffer('')
+        }));
+
+        stream.end();
+    });
+
 
     it('should set custom viewport', function (done) {
         var stream = qunit({'page': {


### PR DESCRIPTION
When multiple phantomjs options are passed in, e.g.
```js
gulp.src('index.html')
    .pipe(qunit({
      'phantomjs-options': ['--ignore-ssl-errors=true', '--web-security=false']
    })
```
The current code will push the array into childArgs, which will result in childProcess.execFile failing to execute phantomjs properly. It will give "Invalid values for 'ignore-ssl-errors' option." It seems that each array element in the 2nd argument of childProcess.execFile must contain a single flag. Passing in the concatenated string '--ignore-ssl-errors=true --web-security=false' does not work.
