### PR TITLE
Add feature: runner-option - adds the option to specify the test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ Default: require("phantomjs").path
 
 The option is used to execute phantomjs binary path
 
+#### options.runner
+
+Type: `String`
+Default: require.resolve('qunit-phantomjs-runner')
+
+This option is used to configure the test runner used to control phantomjs
+
 ## License
 
 MIT © [Jonathan Kemp](http://jonkemp.com)

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ module.exports = function (params) {
     return through.obj(function (file, enc, cb) {
         var absolutePath = path.resolve(file.path),
             isAbsolutePath = absolutePath.indexOf(file.path) >= 0,
-            childArgs = [];
+            childArgs = [],
+            runner = options.runner || require.resolve('qunit-phantomjs-runner');
 
         if (options['phantomjs-options'] && options['phantomjs-options'].length) {
             if (Array.isArray(options['phantomjs-options'])) {
@@ -27,7 +28,7 @@ module.exports = function (params) {
         }
 
         childArgs.push(
-            require.resolve('qunit-phantomjs-runner'),
+            runner,
             (isAbsolutePath ? 'file:///' + absolutePath.replace(/\\/g, '/') : file.path)
         );
 


### PR DESCRIPTION
This is a feature request to enable configuring the test runner that is used. I wanted to convert the output of my tests to junit using the `qunit-reporter-junit` module but in order to allow that to happen, I needed to change the test runner from `qunit-phantomjs-runner`.